### PR TITLE
DATA-1375 Fix and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Datadog Management Tools
 
 This repository contains a set of tools to backup and restore Datadog
-dashboards, screenboards, and monitors to and from local JSON files.
+dashboards, screenboards, and monitors to and from local JSON
+files. By committing these JSON files to a Git repository, you can
+maintain a auditable history of changes.
 
 ## Requirements
 
@@ -34,3 +36,30 @@ To make a copy of a single dashboard, screenboard, or monitor:
 ```bash
 bundle exec datadog-restore.rb --object dashboard --file /path/to/dashboards/Some\ Dashboard.json --altname "Copy of Some Dashboard"
 ```
+
+## Deployment
+
+This application is intended to deployed to AWS ECS, which requires a Dockert image to be built and published to Docker Hub, and for AWS Param Store params to be set:
+
+1. The Docker image must be built and published as follows (set VERSION, below):
+```
+docker build . --file ci/Dockerfile --tag chanzuckerberg/datadog-management:<VERSION>
+docker push chanzuckerberg/datadog-management:<VERSION>
+```
+
+Note: The image that is built is (currently) hardcoded to perform a backup of the Datadog state and commit it to the [meta-datadog-config](https://github.com/chanzuckerberg/meta-datadog-config) Github Repo.
+
+Note: The Docker image's entrypoint expects that following environment variables to be set at run-time:    
+
+- ENV: A value of either `dev`, `staging`, or `prod`
+- SERVICE: The name of the service, which will be used to find additional configuration parameters in AWS Param Store
+
+2. You must generate an RSA key pair. The public key of the pair must be
+set [here](https://github.com/chanzuckerberg/meta-datadog-config/settings/keys) as the Deploy Key [meta-datadog-config](https://github.com/chanzuckerberg/meta-datadog-config) Github Repo. The private key will set as an AWS Param Store parameter (see below). 
+
+3. The Docker image's entrypoint expects that following AWS Param Store variables to be set under the `meta-<ENV>-<SERVICE>`:
+- DD_API_KEY: An API key set on the (Datadog Integration API page)[https://app.datadoghq.com/account/settings#api]
+- DD_APP_KEY: An application key set on the (Datadog Integration API page)[https://app.datadoghq.com/account/settings#api]
+- GITHUB_DEPLOY_KEY: The private key of an RSA key pair. Use "\n" for line breaks when specifying the value, since this is a multi-line value.
+
+4. Update `chanzuckerberg/meta-infra` Git repo [here](https://github.com/chanzuckerberg/meta-infra/blob/master/terraform/envs/prod/datadog-backup/main.tf#L4) to bump the prod environment VERSION of the Docker image (set above).

--- a/ci/docker_entrypoint.sh
+++ b/ci/docker_entrypoint.sh
@@ -21,7 +21,8 @@ cd /opt && \
 cd /meta-datadog-config
 git config user.name 'CZI Datadog Management'
 git config user.email '<>'
-git commit --all --message 'Backup of latest Datadog state'
+git add --all
+git commit --message 'Backup of latest Datadog state'
 git push origin HEAD
 
 


### PR DESCRIPTION
- Add all new Datadog state files to Git repo, ensuring new Dashboards and
  Monitors are being backed up.
- Document the build and deployment process